### PR TITLE
impl APIs for managing machine identity tokens

### DIFF
--- a/crates/nebula-authorization/src/database/machine_identity_token.rs
+++ b/crates/nebula-authorization/src/database/machine_identity_token.rs
@@ -1,0 +1,20 @@
+use chrono::{DateTime, Utc};
+use sea_orm::prelude::*;
+
+use super::UlidId;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "machine_identity_token")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: UlidId,
+    pub machine_identity_id: UlidId,
+    pub token: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/nebula-authorization/src/database/mod.rs
+++ b/crates/nebula-authorization/src/database/mod.rs
@@ -20,6 +20,7 @@ use url::Url;
 
 pub(crate) mod machine_identity;
 pub(crate) mod machine_identity_attribute;
+pub(crate) mod machine_identity_token;
 pub(crate) mod types;
 
 pub(crate) enum AuthMethod {

--- a/crates/nebula-authorization/src/server/router/mod.rs
+++ b/crates/nebula-authorization/src/server/router/mod.rs
@@ -250,7 +250,7 @@ async fn get_machine_identity(
     transaction: &DatabaseTransaction,
     machine_identity_id: &Ulid,
 ) -> Result<MachineIdentity, MachineIdentityError> {
-    application.machine_identity_service.get_machine_identity(&transaction, &machine_identity_id).await?.ok_or_else(
+    application.machine_identity_service.get_machine_identity(transaction, machine_identity_id).await?.ok_or_else(
         || MachineIdentityError::MachineIdentityNotExists {
             entered_machine_identity_id: machine_identity_id.to_owned(),
         },


### PR DESCRIPTION
# impl APIs for managing machine identity tokens

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This PR implements a set of APIs for managing machine identity tokens. The implemented APIs are as follows:
GET machine identity tokens
GET single machine identity token
POST machine identity token
DELETE machine identity token
