### PR TITLE
refactor: switch from Bls24479 to Bn462 Curve for params

### DIFF
--- a/crates/nebula-authority/src/domain/backbone.rs
+++ b/crates/nebula-authority/src/domain/backbone.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use nebula_abe::{curves::bls24479::Bls24479Curve, schemes::isabella24::GlobalParams};
+use nebula_abe::{curves::bn462::Bn462Curve, schemes::isabella24::GlobalParams};
 use serde::Deserialize;
 
 #[async_trait]
 pub trait BackboneService {
-    async fn global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bls24479Curve>>;
+    async fn global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bn462Curve>>;
 }
 
 #[async_trait]
 pub trait BackboneClient {
-    async fn get_global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bls24479Curve>>;
+    async fn get_global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bn462Curve>>;
 }
 
 pub struct WorkspaceBackboneClient {
@@ -43,7 +43,7 @@ struct ParameterResponse {
 
 #[async_trait]
 impl BackboneClient for WorkspaceBackboneClient {
-    async fn get_global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bls24479Curve>> {
+    async fn get_global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bn462Curve>> {
         let url = format!("{}/workspaces/{}/parameter", self.host, workspace_name);
         let response = self.client.get(&url).send().await?;
         let parameter: ParameterResponse = response.json().await?;
@@ -71,7 +71,7 @@ impl WorkspaceBackboneService {
 
 #[async_trait]
 impl BackboneService for WorkspaceBackboneService {
-    async fn global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bls24479Curve>> {
+    async fn global_params(&self, workspace_name: &str) -> Result<GlobalParams<Bn462Curve>> {
         self.backbone_client.get_global_params(workspace_name).await
     }
 }

--- a/crates/nebula-backbone/src/application/parameter/mod.rs
+++ b/crates/nebula-backbone/src/application/parameter/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use nebula_abe::{curves::bls24479::Bls24479Curve, schemes::isabella24::GlobalParams};
+use nebula_abe::{curves::bn462::Bn462Curve, schemes::isabella24::GlobalParams};
 use sea_orm::DatabaseConnection;
 
 use crate::{
@@ -46,7 +46,7 @@ impl ParameterUseCase for ParameterUseCaseImpl {
 
 pub(crate) struct ParameterData {
     pub version: i32,
-    pub value: GlobalParams<Bls24479Curve>,
+    pub value: GlobalParams<Bn462Curve>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -80,7 +80,7 @@ mod test {
     use std::sync::Arc;
 
     use nebula_abe::{
-        curves::{bls24479::Bls24479Curve, PairingCurve},
+        curves::{bn462::Bn462Curve, PairingCurve},
         schemes::isabella24::GlobalParams,
     };
     use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
@@ -97,12 +97,12 @@ mod test {
 
         let mock_connection = Arc::new(mock_database.into_connection());
 
-        let mut rng = <Bls24479Curve as PairingCurve>::Rng::new();
+        let mut rng = <Bn462Curve as PairingCurve>::Rng::new();
         let mut mock_parameter_service = MockParameterService::new();
         mock_parameter_service
             .expect_get()
             .times(1)
-            .returning(move |_| Ok(Parameter { version: 1, value: GlobalParams::<Bls24479Curve>::new(&mut rng) }));
+            .returning(move |_| Ok(Parameter { version: 1, value: GlobalParams::<Bn462Curve>::new(&mut rng) }));
 
         let parameter_usecase = ParameterUseCaseImpl::new(
             workspace_name.clone(),

--- a/crates/nebula-backbone/src/domain/parameter/mod.rs
+++ b/crates/nebula-backbone/src/domain/parameter/mod.rs
@@ -10,13 +10,13 @@ use ulid::Ulid;
 
 use crate::database::parameter;
 use nebula_abe::{
-    curves::{bls24479::Bls24479Curve, PairingCurve},
+    curves::{bn462::Bn462Curve, PairingCurve},
     schemes::isabella24::GlobalParams,
 };
 
 pub(crate) struct Parameter {
     pub version: i32,
-    pub value: GlobalParams<Bls24479Curve>,
+    pub value: GlobalParams<Bn462Curve>,
 }
 
 #[cfg_attr(test, automock)]
@@ -42,12 +42,12 @@ impl ParameterService for PostgresParameterService {
             return Err(Error::ParameterAlreadyCreated(PARAMETER_VERSION));
         }
 
-        let mut rng = <Bls24479Curve as PairingCurve>::Rng::new();
+        let mut rng = <Bn462Curve as PairingCurve>::Rng::new();
         let mut seed = [0u8; 64];
         OsRng.fill(&mut seed);
         rng.seed(&seed);
 
-        let gp = GlobalParams::<Bls24479Curve>::new(&mut rng);
+        let gp = GlobalParams::<Bn462Curve>::new(&mut rng);
         let value = rmp_serde::to_vec(&gp)?;
         let now = Utc::now();
         parameter::ActiveModel {
@@ -70,7 +70,7 @@ impl ParameterService for PostgresParameterService {
             .await?
             .ok_or(Error::ParameterNotFound)?;
         let value = parameter.value;
-        let gp: GlobalParams<Bls24479Curve> = rmp_serde::from_slice(&value)?;
+        let gp: GlobalParams<Bn462Curve> = rmp_serde::from_slice(&value)?;
         Ok(Parameter { version: PARAMETER_VERSION, value: gp })
     }
 }
@@ -107,7 +107,7 @@ mod test {
 
     use chrono::Utc;
     use nebula_abe::{
-        curves::{bls24479::Bls24479Curve, PairingCurve},
+        curves::{bn462::Bn462Curve, PairingCurve},
         schemes::isabella24::GlobalParams,
     };
     use sea_orm::{DatabaseBackend, DbErr, MockDatabase, TransactionTrait};
@@ -120,8 +120,8 @@ mod test {
     #[tokio::test]
     async fn when_creating_parameter_is_successful_then_parameter_service_returns_ok() {
         use crate::database::parameter::Model;
-        let mut rng = <Bls24479Curve as PairingCurve>::Rng::new();
-        let gp = GlobalParams::<Bls24479Curve>::new(&mut rng);
+        let mut rng = <Bn462Curve as PairingCurve>::Rng::new();
+        let gp = GlobalParams::<Bn462Curve>::new(&mut rng);
         let value = rmp_serde::to_vec(&gp).expect("serializing global params should be successful");
 
         let now = Utc::now();
@@ -169,8 +169,8 @@ mod test {
     #[tokio::test]
     async fn when_getting_parameter_is_successful_then_parameter_service_returns_ok() {
         use crate::database::parameter::Model;
-        let mut rng = <Bls24479Curve as PairingCurve>::Rng::new();
-        let gp = GlobalParams::<Bls24479Curve>::new(&mut rng);
+        let mut rng = <Bn462Curve as PairingCurve>::Rng::new();
+        let gp = GlobalParams::<Bn462Curve>::new(&mut rng);
         let value = rmp_serde::to_vec(&gp).expect("serializing global params should be successful");
 
         let now = Utc::now();


### PR DESCRIPTION
# refactor: switch from Bls24479 to Bn462 Curve for params

<!-- Thank you for submitting a pull request to our repo. -->

- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request refactors the cryptographic curve used in our parameterization process from Bls24479 to Bn462.