### PR TITLE
feat: implement issuing the JWT for a machine identity

### DIFF
--- a/crates/nebula-authorization/src/application.rs
+++ b/crates/nebula-authorization/src/application.rs
@@ -6,25 +6,18 @@ use crate::{
     domain::{
         connector::saml::{SAMLConnector, SAMLConnertorConfig},
         machine_identity::MachineIdentityService,
+        token::TokenService,
     },
 };
 
 use nebula_token::jwk::jwk_set::{JwkSet, JWK_SET_DEFAULT_KEY_ID};
 use sea_orm::DatabaseConnection;
-use url::Url;
 
 pub struct Application {
-    pub base_url: Url,
     pub database_connection: Arc<DatabaseConnection>,
     pub connector: Arc<SAMLConnector>,
     pub token_service: Arc<TokenService>,
     pub machine_identity_service: Arc<MachineIdentityService>,
-}
-
-pub struct TokenService {
-    pub lifetime: u64,
-    pub jwks: JwkSet,
-    pub jwk_kid: String,
 }
 
 impl Application {
@@ -54,10 +47,9 @@ impl Application {
         };
 
         Ok(Self {
-            base_url: config.base_url.clone(),
             database_connection,
             connector: saml_connector,
-            token_service: Arc::new(TokenService { lifetime: config.token.lifetime, jwks, jwk_kid: kid }),
+            token_service: Arc::new(TokenService::new(config.base_url.clone(), config.token.lifetime, jwks, kid)),
             machine_identity_service: Arc::new(MachineIdentityService {}),
         })
     }

--- a/crates/nebula-authorization/src/domain/connector/mod.rs
+++ b/crates/nebula-authorization/src/domain/connector/mod.rs
@@ -12,3 +12,9 @@ pub struct Identity {
     pub role: Role,
     pub claims: HashMap<String, String>,
 }
+
+impl Identity {
+    pub fn new(user_id: String, workspace_name: String, role: Role, claims: HashMap<String, String>) -> Self {
+        Self { user_id, workspace_name, role, claims }
+    }
+}

--- a/crates/nebula-authorization/src/domain/machine_identity/mod.rs
+++ b/crates/nebula-authorization/src/domain/machine_identity/mod.rs
@@ -3,11 +3,16 @@ use std::collections::HashSet;
 use axum::async_trait;
 use chrono::Utc;
 use rand::{distributions::Alphanumeric, Rng};
-use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseTransaction, DbErr, EntityTrait, LoaderTrait, QueryFilter, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseTransaction, DbErr, EntityTrait, LoaderTrait, QueryFilter, QuerySelect as _,
+    QueryTrait as _, Set,
+};
 use thiserror::Error;
 use ulid::Ulid;
 
 use crate::database::{machine_identity, machine_identity_attribute, machine_identity_token, Persistable, UlidId};
+
+use super::connector::Identity;
 
 pub struct MachineIdentity {
     pub id: Ulid,
@@ -234,6 +239,37 @@ impl MachineIdentityService {
             .await?;
 
         Ok(token.map(MachineIdentityToken::from))
+    }
+
+    pub async fn get_machine_identity_by_token(
+        &self,
+        transaction: &DatabaseTransaction,
+        token: &str,
+    ) -> Result<Option<MachineIdentity>> {
+        let machine_identity = if let Some(machine_identity) = machine_identity::Entity::find()
+            .filter(
+                machine_identity::Column::Id.in_subquery(
+                    machine_identity_token::Entity::find()
+                        .select_only()
+                        .column(machine_identity_token::Column::MachineIdentityId)
+                        .filter(machine_identity_token::Column::Token.eq(token))
+                        .into_query(),
+                ),
+            )
+            .one(transaction)
+            .await?
+        {
+            machine_identity
+        } else {
+            return Ok(None);
+        };
+
+        let attributes = machine_identity_attribute::Entity::find()
+            .filter(machine_identity_attribute::Column::MachineIdentityId.eq(machine_identity.id))
+            .all(transaction)
+            .await?;
+
+        Ok(Some((machine_identity, attributes).into()))
     }
 }
 

--- a/crates/nebula-authorization/src/domain/machine_identity/mod.rs
+++ b/crates/nebula-authorization/src/domain/machine_identity/mod.rs
@@ -12,8 +12,6 @@ use ulid::Ulid;
 
 use crate::database::{machine_identity, machine_identity_attribute, machine_identity_token, Persistable, UlidId};
 
-use super::connector::Identity;
-
 pub struct MachineIdentity {
     pub id: Ulid,
     pub label: String,

--- a/crates/nebula-authorization/src/domain/mod.rs
+++ b/crates/nebula-authorization/src/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod connector;
 pub mod machine_identity;
+pub mod token;

--- a/crates/nebula-authorization/src/domain/token/mod.rs
+++ b/crates/nebula-authorization/src/domain/token/mod.rs
@@ -18,8 +18,8 @@ pub struct TokenService {
     pub jwk_kid: String,
 }
 
-const DEFAULT_ALGORITHM: &'static str = "ES256";
-const ISSUER: &'static str = "nebula-authorization";
+const DEFAULT_ALGORITHM: &str = "ES256";
+const ISSUER: &str = "nebula-authorization";
 
 impl TokenService {
     pub fn new(base_url: Url, lifetime: u64, jwks: JwkSet, jwk_kid: String) -> Self {

--- a/crates/nebula-authorization/src/domain/token/mod.rs
+++ b/crates/nebula-authorization/src/domain/token/mod.rs
@@ -1,0 +1,57 @@
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use nebula_token::{
+    claim::{ATTRIBUTES_CLAIM, ROLE_CLAIM, WORKSPACE_NAME_CLAIM},
+    jwk::jwk_set::JwkSet,
+    jwt::Jwt,
+    JwsHeader, JwtPayload, Map, Value,
+};
+use url::Url;
+
+use super::connector::Identity;
+
+pub struct TokenService {
+    pub base_url: Url,
+    pub lifetime: u64,
+    pub jwks: JwkSet,
+    pub jwk_kid: String,
+}
+
+const DEFAULT_ALGORITHM: &'static str = "ES256";
+const ISSUER: &'static str = "nebula-authorization";
+
+impl TokenService {
+    pub fn new(base_url: Url, lifetime: u64, jwks: JwkSet, jwk_kid: String) -> Self {
+        Self { base_url, lifetime, jwks, jwk_kid }
+    }
+
+    pub fn create_jwt(&self, identity: &Identity) -> Result<Jwt> {
+        let mut jws_header = JwsHeader::new();
+        jws_header.set_jwk_set_url(self.base_url.join("/jwks").expect("failed to create jwks url"));
+        jws_header.set_key_id(&self.jwk_kid);
+        jws_header.set_algorithm(DEFAULT_ALGORITHM);
+
+        let mut jwt_payload = JwtPayload::new();
+        jwt_payload.set_claim(
+            ATTRIBUTES_CLAIM,
+            Some(Value::Object(
+                identity.claims.iter().map(|(k, v)| (k.to_string(), v.to_string().into())).collect::<Map<_, _>>(),
+            )),
+        )?;
+        jwt_payload.set_subject(&identity.user_id);
+        jwt_payload.set_issuer(ISSUER);
+        jwt_payload.set_claim(WORKSPACE_NAME_CLAIM, Some(identity.workspace_name.clone().into())).unwrap();
+        jwt_payload.set_claim(ROLE_CLAIM, Some(String::from(identity.role.clone()).into())).unwrap();
+
+        let now = SystemTime::now();
+        let expires_at = now + Duration::from_secs(self.lifetime);
+        jwt_payload.set_expires_at(&expires_at);
+        jwt_payload.set_issued_at(&now);
+
+        let jwt =
+            Jwt::new(jws_header, jwt_payload, self.jwks.get(&self.jwk_kid).expect("failed to get jwk from jwk set"))?;
+
+        Ok(jwt)
+    }
+}

--- a/crates/nebula-authorization/src/server/router/mod.rs
+++ b/crates/nebula-authorization/src/server/router/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::sync::Arc;
 
 use axum::{
     extract::{Path, State},
@@ -11,12 +8,7 @@ use axum::{
     Form, Json, Router,
 };
 use axum_thiserror::ErrorStatus;
-use nebula_token::{
-    claim::{Role, ATTRIBUTES_CLAIM, ROLE_CLAIM, WORKSPACE_NAME_CLAIM},
-    jwk::jwk_set::PublicJwkSet,
-    jwt::Jwt,
-    JwsHeader, JwtPayload, Map, Value,
-};
+use nebula_token::{claim::Role, jwk::jwk_set::PublicJwkSet, jwt::Jwt};
 use sea_orm::{DatabaseTransaction, DbErr};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;


### PR DESCRIPTION
# feat: implement issuing the JWT for a machine identity

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request introduces the functionality to issue JSON Web Tokens (JWT) for machine identities. This feature is essential for enhancing the security and authentication processes for our application's automated systems by providing them with secure tokens for identity verification without human intervention. 


Note: Please remember to implement access control for sub-paths related to machine identity using tokens in the future.