### PR TITLE
remove attributes from registering machine identity logic

### DIFF
--- a/crates/nebula-authorization/src/domain/machine_identity/mod.rs
+++ b/crates/nebula-authorization/src/domain/machine_identity/mod.rs
@@ -131,12 +131,7 @@ impl From<(machine_identity::Model, Vec<machine_identity_attribute::Model>)> for
 }
 
 impl MachineIdentityService {
-    pub async fn register_machine_identity(
-        &self,
-        transaction: &DatabaseTransaction,
-        label: &str,
-        attributes: &[(&str, &str)],
-    ) -> Result<()> {
+    pub async fn register_machine_identity(&self, transaction: &DatabaseTransaction, label: &str) -> Result<()> {
         let machine_identity_id = UlidId::new(Ulid::new());
         let now = Utc::now();
         machine_identity::ActiveModel {
@@ -147,20 +142,6 @@ impl MachineIdentityService {
         }
         .insert(transaction)
         .await?;
-
-        if !attributes.is_empty() {
-            let attributes_active_models =
-                attributes.iter().map(|(key, value)| machine_identity_attribute::ActiveModel {
-                    id: Set(UlidId::new(Ulid::new())),
-                    machine_identity_id: Set(machine_identity_id),
-                    key: Set(key.to_string()),
-                    value: Set(value.to_string()),
-                    created_at: Set(now),
-                    updated_at: Set(now),
-                });
-
-            machine_identity_attribute::Entity::insert_many(attributes_active_models).exec(transaction).await?;
-        }
 
         Ok(())
     }

--- a/crates/nebula-authorization/src/server/router/mod.rs
+++ b/crates/nebula-authorization/src/server/router/mod.rs
@@ -196,7 +196,6 @@ pub struct Attribute {
 #[serde(rename_all = "camelCase")]
 pub struct PostMachineIdentityRequest {
     label: String,
-    attributes: Vec<Attribute>,
 }
 
 #[derive(Error, Debug, ErrorStatus)]
@@ -225,12 +224,9 @@ async fn handle_post_machine_identity(
     State(application): State<Arc<Application>>,
     Json(payload): Json<PostMachineIdentityRequest>,
 ) -> Result<impl IntoResponse, MachineIdentityError> {
-    let attributes: Vec<_> =
-        payload.attributes.iter().map(|attribute| (attribute.key.as_str(), attribute.value.as_str())).collect();
-
     let transaction = application.database_connection.begin_with_workspace_scope(&workspace_name).await?;
 
-    application.machine_identity_service.register_machine_identity(&transaction, &payload.label, &attributes).await?;
+    application.machine_identity_service.register_machine_identity(&transaction, &payload.label).await?;
 
     transaction.commit().await?;
 


### PR DESCRIPTION
# remove attributes from registering machine identity logic

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This PR excludes attribute registration during the process of creating machine identities. At this stage, the registration of machine identities should be open to all members; however, the responsibility for managing attributes lies with the administrator. Therefore, attributes should not be registered simultaneously when creating machine identities. Once the authorization server is capable of persistently managing member attributes, this feature should be re-enabled.

