### PR TITLE
persist machine identity with owner gid

### DIFF
--- a/crates/nebula-authorization/src/database/machine_identity.rs
+++ b/crates/nebula-authorization/src/database/machine_identity.rs
@@ -8,6 +8,7 @@ use super::UlidId;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: UlidId,
+    pub owner_gid: String,
     pub label: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/crates/nebula-authorization/src/domain/machine_identity/mod.rs
+++ b/crates/nebula-authorization/src/domain/machine_identity/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use axum::async_trait;
 use chrono::Utc;
+use nebula_token::claim::NebulaClaim;
 use rand::{distributions::Alphanumeric, Rng};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseTransaction, DbErr, EntityTrait, LoaderTrait, QueryFilter, QuerySelect as _,
@@ -131,11 +132,17 @@ impl From<(machine_identity::Model, Vec<machine_identity_attribute::Model>)> for
 }
 
 impl MachineIdentityService {
-    pub async fn register_machine_identity(&self, transaction: &DatabaseTransaction, label: &str) -> Result<()> {
+    pub async fn register_machine_identity(
+        &self,
+        transaction: &DatabaseTransaction,
+        owner_claim: &NebulaClaim,
+        label: &str,
+    ) -> Result<()> {
         let machine_identity_id = UlidId::new(Ulid::new());
         let now = Utc::now();
         machine_identity::ActiveModel {
             id: Set(machine_identity_id),
+            owner_gid: Set(owner_claim.gid.to_owned()),
             label: Set(label.to_owned()),
             created_at: Set(now),
             updated_at: Set(now),


### PR DESCRIPTION
# persist machine identity with owner gid

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description

This PR extends functionality to include and store the owner's GID when creating a machine identity. The owner's GID will be used to further enhance the feature of synchronizing the machine identity's attributes with the owner's attributes in the future.