### PR TITLE
feat(authz): enhance security with middleware & auth layers

### DIFF
--- a/crates/nebula-authorization/src/domain/machine_identity/mod.rs
+++ b/crates/nebula-authorization/src/domain/machine_identity/mod.rs
@@ -15,6 +15,7 @@ use crate::database::{machine_identity, machine_identity_attribute, machine_iden
 
 pub struct MachineIdentity {
     pub id: Ulid,
+    pub owner_gid: String,
     pub label: String,
     pub attributes: Vec<(String, String)>,
     updated_attributes: Option<Vec<(String, String)>>,
@@ -121,6 +122,7 @@ impl From<(machine_identity::Model, Vec<machine_identity_attribute::Model>)> for
         Self {
             id: machine_identity_model.id.inner(),
             label: machine_identity_model.label,
+            owner_gid: machine_identity_model.owner_gid,
             attributes: machine_identity_attribute_models
                 .into_iter()
                 .map(|attribute| (attribute.key, attribute.value))


### PR DESCRIPTION
# feat(authz): enhance security with middleware & auth layers

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request introduces to our authorization system by incorporating an access control middleware, alongside layered authentication features. The changes aim to bolster security within the application by refining how access permissions are handled and verified at various stages.

Here's the rule: 
1. All workspace users can view the list of machine identities, retrieve individual machine identities, and create new ones.
2. Only admins can modify individual attributes of a machine identity.
3. Deleting a machine identity is restricted to admins and the identity’s owner.
4. Viewing, creating, or deleting tokens associated with a machine identity is limited to admins and the owner.
