### PR TITLE
feat: add PostgresKeyPairService for key management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,6 +2509,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sigv4",
  "axum",
  "axum_thiserror",
  "base64 0.22.1",
@@ -2523,12 +2526,14 @@ dependencies = [
  "rand",
  "reqwest",
  "rmp-serde",
+ "sea-orm",
  "serde",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "zeroize",
 ]
 

--- a/crates/nebula-authority/Cargo.toml
+++ b/crates/nebula-authority/Cargo.toml
@@ -30,6 +30,11 @@ cached = { version = "0.54", features = [
     "async",
     "async_tokio_rt_multi_thread",
 ] }
+sea-orm = { workspace = true, features = ["mock"] }
+aws-config = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sigv4 = { workspace = true }
+urlencoding = { workspace = true }
 # nebula packages
 nebula-abe = { workspace = true, features = ["zeroize"] }
 nebula-storage = { workspace = true, features = ["zeroize", "shield"] }

--- a/crates/nebula-authority/src/config.rs
+++ b/crates/nebula-authority/src/config.rs
@@ -20,6 +20,22 @@ pub(crate) struct ApplicationConfig {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "type")]
 pub(crate) enum StorageConfig {
     File { path: String },
+    Postgres(PostgresConfig),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PostgresConfig {
+    pub host: String,
+    pub port: u16,
+    pub database_name: String,
+    pub auth: PostgresAuthMethod,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE", tag = "type")]
+pub(crate) enum PostgresAuthMethod {
+    Credential { username: String, password: Option<String> },
+    RdsIamAuth { username: String },
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/nebula-authority/src/database.rs
+++ b/crates/nebula-authority/src/database.rs
@@ -1,0 +1,122 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use aws_config::BehaviorVersion;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::{
+    http_request::{sign, SignableBody, SignableRequest, SigningSettings},
+    sign::v4::SigningParams,
+};
+use sea_orm::sqlx::postgres::PgConnectOptions;
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+use url::Url;
+
+pub(crate) enum AuthMethod {
+    Credential { username: String, password: Option<String> },
+    RdsIamAuth { host: String, port: u16, username: String },
+}
+
+async fn generate_rds_iam_token(db_hostname: &str, port: u16, db_username: &str) -> anyhow::Result<String> {
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+
+    let credentials = config
+        .credentials_provider()
+        .expect("no credentials provider found")
+        .provide_credentials()
+        .await
+        .expect("unable to load credentials");
+    let identity = credentials.into();
+    let region = config.region().unwrap().to_string();
+
+    let mut signing_settings = SigningSettings::default();
+    signing_settings.expires_in = Some(Duration::from_secs(900));
+    signing_settings.signature_location = aws_sigv4::http_request::SignatureLocation::QueryParams;
+
+    let signing_params = SigningParams::builder()
+        .identity(&identity)
+        .region(&region)
+        .name("rds-db")
+        .time(SystemTime::now())
+        .settings(signing_settings)
+        .build()?;
+
+    let url = format!(
+        "https://{db_hostname}:{port}/?Action=connect&DBUser={db_user}",
+        db_hostname = db_hostname,
+        port = port,
+        db_user = db_username
+    );
+
+    let signable_request =
+        SignableRequest::new("GET", &url, std::iter::empty(), SignableBody::Bytes(&[])).expect("signable request");
+
+    let (signing_instructions, _signature) = sign(signable_request, &signing_params.into())?.into_parts();
+
+    let mut url = url::Url::parse(&url).unwrap();
+    for (name, value) in signing_instructions.params() {
+        url.query_pairs_mut().append_pair(name, value);
+    }
+
+    let response = url.to_string().split_off("https://".len());
+
+    Ok(response)
+}
+
+pub async fn connect_to_database(
+    host: &str,
+    port: u16,
+    database_name: &str,
+    auth: &AuthMethod,
+) -> anyhow::Result<Arc<DatabaseConnection>> {
+    let mut options = match auth {
+        AuthMethod::Credential { username, password } => {
+            let mut conn_str = Url::parse(&format!("postgres://{host}:5432/{database_name}?sslmode=Prefer"))?;
+            conn_str.set_username(username).unwrap();
+            conn_str.set_password(password.as_deref()).unwrap();
+            ConnectOptions::new(conn_str)
+        }
+        AuthMethod::RdsIamAuth { host: auth_host, port: auth_port, username } => {
+            let password = generate_rds_iam_token(auth_host, *auth_port, username).await?;
+            let mut conn_str = Url::parse(&format!("postgres://{host}:{port}/postgres?sslmode=Prefer"))?;
+            conn_str.set_username(username).unwrap();
+            conn_str.set_password(Some(urlencoding::encode(&password).as_ref())).unwrap();
+            ConnectOptions::new(conn_str)
+        }
+    };
+
+    options.sqlx_logging_level(tracing::log::LevelFilter::Debug);
+
+    let connection = Arc::new(Database::connect(options).await?);
+
+    if let AuthMethod::RdsIamAuth { host: auth_host, port: auth_port, username } = auth {
+        reassign_token_periodically_to_database(connection.clone(), auth_host.clone(), *auth_port, username.clone());
+    };
+
+    Ok(connection)
+}
+
+fn reassign_token_periodically_to_database(
+    database: Arc<DatabaseConnection>,
+    database_host: String,
+    database_port: u16,
+    database_user: String,
+) {
+    tokio::spawn({
+        async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(600)).await;
+                if let Ok(token) = generate_rds_iam_token(&database_host, database_port, &database_user).await {
+                    let pool = database.get_postgres_connection_pool();
+                    let new_option = PgConnectOptions::new()
+                        .host(&database_host)
+                        .database("postgres")
+                        .username(&database_user)
+                        .password(&token);
+                    pool.set_connect_options(new_option);
+                }
+            }
+        }
+    });
+}

--- a/crates/nebula-authority/src/database.rs
+++ b/crates/nebula-authority/src/database.rs
@@ -72,7 +72,7 @@ pub async fn connect_to_database(
 ) -> anyhow::Result<Arc<DatabaseConnection>> {
     let mut options = match auth {
         AuthMethod::Credential { username, password } => {
-            let mut conn_str = Url::parse(&format!("postgres://{host}:5432/{database_name}?sslmode=Prefer"))?;
+            let mut conn_str = Url::parse(&format!("postgres://{host}:{port}/{database_name}?sslmode=Prefer"))?;
             conn_str.set_username(username).unwrap();
             conn_str.set_password(password.as_deref()).unwrap();
             ConnectOptions::new(conn_str)

--- a/crates/nebula-authority/src/domain/key_pair.rs
+++ b/crates/nebula-authority/src/domain/key_pair.rs
@@ -7,7 +7,7 @@ use nebula_abe::{
 };
 use nebula_secret_sharing::shamir::{combine, split, Share};
 use nebula_storage::{
-    backend::file::FileStorage,
+    backend::{file::FileStorage, postgres::PostgresStorage},
     shield::{aes::AESShieldStorage, Shield},
     Storage as _,
 };
@@ -126,6 +126,107 @@ impl KeyPairService for FileKeyPairService<'_> {
 
 #[async_trait]
 impl ShieldedKeyPairService for FileKeyPairService<'_> {
+    async fn shield_initialize(&self, share: usize, threshold: usize) -> Result<Vec<Share>> {
+        if self.storage.is_initialized().await? {
+            bail!("shield storage is already initialized");
+        }
+
+        let master_key = self.storage.generate_key().await?;
+        let shares = split(&master_key, share, threshold);
+        self.storage.initialize(&master_key).await?;
+
+        self.storage.disarm(&master_key).await?; // Disarm the storage immediately after initialization
+        Ok(shares)
+    }
+
+    async fn storage_armor(&self) -> Result<()> {
+        Ok(self.storage.armor().await?)
+    }
+
+    async fn storage_disarm(&self, shares: &[Share]) -> Result<()> {
+        let master_key = Zeroizing::new(combine(shares));
+        Ok(self.storage.disarm(&master_key).await?)
+    }
+}
+
+pub struct PostgresKeyPairService {
+    storage: AESShieldStorage<PostgresStorage>,
+}
+
+impl PostgresKeyPairService {
+    pub fn new(storage: PostgresStorage) -> Self {
+        Self { storage: AESShieldStorage::new(storage) }
+    }
+}
+
+#[async_trait]
+impl KeyPairService for PostgresKeyPairService {
+    async fn generate_latest_key_pair(
+        &self,
+        gp: &GlobalParams<Bn462Curve>,
+        name: &str,
+    ) -> Result<(KeyPair, KeyVersion)> {
+        let mut seed = [0u8; 32];
+        OsRng.fill_bytes(&mut seed);
+        let mut rng = MiraclRng::new();
+        rng.seed(&seed);
+
+        let version_path = self.version_path(name);
+        let latest_version = self.latest_key_pair_version(name).await?.unwrap_or(0);
+
+        let new_version = latest_version + 1;
+        let new_version_path = self.key_pair_path(name, new_version);
+
+        let name_with_version = format!("{}#{}", name, new_version);
+        let key_pair = KeyPair::new(&mut rng, gp, name_with_version);
+        let key_pair_bytes = rmp_serde::to_vec(&key_pair)?;
+
+        self.storage.set(&new_version_path, &key_pair_bytes).await?;
+        self.storage.set(&version_path, new_version.to_string().as_bytes()).await?;
+
+        Ok((key_pair, new_version))
+    }
+
+    async fn latest_key_pair_version(&self, name: &str) -> Result<Option<KeyVersion>> {
+        let version_path = self.version_path(name);
+        let version = self.storage.get(&version_path).await?;
+        match version {
+            Some(version) => {
+                let version: KeyVersion = String::from_utf8(version)?.parse()?;
+                Ok(Some(version))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn latest_key_pair(&self, name: &str) -> Result<Option<(KeyPair, KeyVersion)>> {
+        let version_path = self.version_path(name);
+        let version = self.storage.get(&version_path).await?;
+
+        match version {
+            Some(version) => {
+                let version: KeyVersion = String::from_utf8(version)?.parse()?;
+                self.key_pair_by_version(name, version).await.map(|key_pair| key_pair.map(|kp| (kp, version)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn key_pair_by_version(&self, name: &str, version: KeyVersion) -> Result<Option<KeyPair>> {
+        let key_pair_path = self.key_pair_path(name, version);
+        let key_pair = self.storage.get(&key_pair_path).await?;
+        match key_pair {
+            Some(key_pair) => {
+                let key_pair: KeyPair = rmp_serde::from_slice(&key_pair)?;
+                Ok(Some(key_pair))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl ShieldedKeyPairService for PostgresKeyPairService {
     async fn shield_initialize(&self, share: usize, threshold: usize) -> Result<Vec<Share>> {
         if self.storage.is_initialized().await? {
             bail!("shield storage is already initialized");

--- a/crates/nebula-authority/src/main.rs
+++ b/crates/nebula-authority/src/main.rs
@@ -11,6 +11,7 @@ use crate::logger::LoggerConfig;
 
 mod application;
 mod config;
+mod database;
 mod domain;
 mod logger;
 mod server;
@@ -31,7 +32,7 @@ async fn main() -> anyhow::Result<()> {
     logger::init_logger(LoggerConfig::default());
     let args = Args::parse();
     let app_config = config::load_config(args.config, args.port)?;
-    let authority = Authority::new(&app_config)?;
+    let authority = Authority::new(&app_config).await?;
     let jwks_discovery: Arc<dyn JwksDiscovery + Send + Sync> = if let Some(refresh_interval) =
         app_config.jwks_refresh_interval
     {

--- a/crates/nebula-authorization/src/database/mod.rs
+++ b/crates/nebula-authorization/src/database/mod.rs
@@ -82,7 +82,7 @@ pub async fn connect_to_database(
 ) -> anyhow::Result<Arc<DatabaseConnection>> {
     let mut options = match auth {
         AuthMethod::Credential { username, password } => {
-            let mut conn_str = Url::parse(&format!("postgres://{host}:5432/{database_name}?sslmode=Prefer"))?;
+            let mut conn_str = Url::parse(&format!("postgres://{host}:{port}/{database_name}?sslmode=Prefer"))?;
             conn_str.set_username(username).unwrap();
             conn_str.set_password(password.as_deref()).unwrap();
             ConnectOptions::new(conn_str)

--- a/crates/nebula-backbone/src/database/mod.rs
+++ b/crates/nebula-backbone/src/database/mod.rs
@@ -90,7 +90,7 @@ pub async fn connect_to_database(
 ) -> anyhow::Result<Arc<DatabaseConnection>> {
     let mut options = match auth {
         AuthMethod::Credential { username, password } => {
-            let mut conn_str = Url::parse(&format!("postgres://{host}:5432/{database_name}?sslmode=Prefer"))?;
+            let mut conn_str = Url::parse(&format!("postgres://{host}:{port}/{database_name}?sslmode=Prefer"))?;
             conn_str.set_username(username).unwrap();
             conn_str.set_password(password.as_deref()).unwrap();
             ConnectOptions::new(conn_str)


### PR DESCRIPTION
# feat: add PostgresKeyPairService for key management

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

This pull request introduces a new service called `PostgresKeyPairService`, which is designed to handle the management of key pairs within a PostgreSQL database environment. The service encapsulates the logic required to create, retrieve, and manage ABE authority key-pairs.