### PR TITLE
create shcema without transaction

### DIFF
--- a/crates/nebula-backbone/src/application/mod.rs
+++ b/crates/nebula-backbone/src/application/mod.rs
@@ -108,6 +108,7 @@ pub(super) async fn init(config: &ApplicationConfig) -> anyhow::Result<Applicati
     .await?;
 
     let workspace_service = Arc::new(WorkspaceServiceImpl::new(
+        database_connection.clone(),
         config.database.host.to_owned(),
         config.database.port,
         config.database.database_name.to_owned(),

--- a/crates/nebula-backbone/src/application/workspace/mod.rs
+++ b/crates/nebula-backbone/src/application/workspace/mod.rs
@@ -48,7 +48,7 @@ impl<W: WorkspaceService + Sync + Send> WorkspaceUseCase for WorkspaceUseCaseImp
     async fn create(&self, cmd: CreatingWorkspaceCommand) -> Result<()> {
         let transaction = self.database_connection.begin().await.map_err(anyhow::Error::from)?;
 
-        self.workspace_service.create(&transaction, &cmd.name).await?;
+        self.workspace_service.create(&self.database_connection, &transaction, &cmd.name).await?;
 
         transaction.commit().await.map_err(anyhow::Error::from)?;
 

--- a/crates/nebula-backbone/src/application/workspace/mod.rs
+++ b/crates/nebula-backbone/src/application/workspace/mod.rs
@@ -48,7 +48,7 @@ impl<W: WorkspaceService + Sync + Send> WorkspaceUseCase for WorkspaceUseCaseImp
     async fn create(&self, cmd: CreatingWorkspaceCommand) -> Result<()> {
         let transaction = self.database_connection.begin().await.map_err(anyhow::Error::from)?;
 
-        self.workspace_service.create(&self.database_connection, &transaction, &cmd.name).await?;
+        self.workspace_service.create(&transaction, &cmd.name).await?;
 
         transaction.commit().await.map_err(anyhow::Error::from)?;
 

--- a/crates/nebula-backbone/src/domain/workspace/workspace_service.rs
+++ b/crates/nebula-backbone/src/domain/workspace/workspace_service.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::Error;
 use crate::{
     database::{migrate_workspace, AuthMethod},
@@ -9,7 +11,7 @@ use chrono::Utc;
 use mockall::automock;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseBackend, DatabaseConnection, DatabaseTransaction, DbErr,
-    EntityTrait, PaginatorTrait, QueryFilter, RuntimeErr, SqlxError, Statement, TransactionTrait,
+    EntityTrait, PaginatorTrait, QueryFilter, RuntimeErr, SqlxError, Statement,
 };
 use tracing::info;
 use ulid::Ulid;
@@ -19,15 +21,11 @@ use ulid::Ulid;
 pub(crate) trait WorkspaceService {
     async fn get_all(&self, transaction: &DatabaseTransaction) -> Result<Vec<Workspace>>;
     async fn get_by_name(&self, transaction: &DatabaseTransaction, name: &str) -> Result<Option<Workspace>>;
-    async fn create(
-        &self,
-        connection: &DatabaseConnection,
-        transaction: &DatabaseTransaction,
-        name: &str,
-    ) -> Result<()>;
+    async fn create(&self, transaction: &DatabaseTransaction, name: &str) -> Result<()>;
 }
 
 pub(crate) struct WorkspaceServiceImpl {
+    connection: Arc<DatabaseConnection>,
     database_host: String,
     database_port: u16,
     database_name: String,
@@ -36,12 +34,13 @@ pub(crate) struct WorkspaceServiceImpl {
 
 impl WorkspaceServiceImpl {
     pub(crate) fn new(
+        connection: Arc<DatabaseConnection>,
         database_host: String,
         database_port: u16,
         database_name: String,
         database_auth: AuthMethod,
     ) -> Self {
-        Self { database_host, database_port, database_name, database_auth }
+        Self { connection, database_host, database_port, database_name, database_auth }
     }
 
     async fn exists_by_name(&self, transaction: &DatabaseTransaction, name: &str) -> Result<bool> {
@@ -69,12 +68,7 @@ impl WorkspaceService for WorkspaceServiceImpl {
         Ok(workspace_model.map(Workspace::from))
     }
 
-    async fn create(
-        &self,
-        connection: &DatabaseConnection,
-        transaction: &DatabaseTransaction,
-        name: &str,
-    ) -> Result<()> {
+    async fn create(&self, transaction: &DatabaseTransaction, name: &str) -> Result<()> {
         use crate::database::workspace::ActiveModel;
         use sea_orm::ActiveValue;
 
@@ -93,16 +87,12 @@ impl WorkspaceService for WorkspaceServiceImpl {
         .insert(transaction)
         .await?;
 
-        dbg!("1");
-
-        connection
+        self.connection
             .execute(Statement::from_string(
                 DatabaseBackend::Postgres,
                 format!("CREATE SCHEMA IF NOT EXISTS \"{name}\";"),
             ))
             .await?;
-
-        dbg!("2");
 
         migrate_workspace(name, &self.database_host, self.database_port, &self.database_name, &self.database_auth)
             .await?;
@@ -167,6 +157,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -175,7 +166,7 @@ mod test {
 
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
-        let result = workspace_service.create(&mock_connection, &transaction, WORKSPACE_NAME).await;
+        let result = workspace_service.create(&transaction, WORKSPACE_NAME).await;
 
         transaction.commit().await.expect("commiting transaction should be successful");
 
@@ -191,6 +182,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -199,7 +191,7 @@ mod test {
 
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
-        let result = workspace_service.create(&mock_connection, &transaction, WORKSPACE_NAME).await;
+        let result = workspace_service.create(&transaction, WORKSPACE_NAME).await;
 
         transaction.commit().await.expect("commiting transaction should be successful");
 
@@ -214,6 +206,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -222,7 +215,7 @@ mod test {
 
         let transaction = mock_connection.begin().await.expect("begining transaction should be successful");
 
-        let result = workspace_service.create(&mock_connection, &transaction, WORKSPACE_NAME).await;
+        let result = workspace_service.create(&transaction, WORKSPACE_NAME).await;
 
         transaction.commit().await.expect("commiting transaction should be successful");
 
@@ -245,6 +238,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -266,6 +260,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -289,6 +284,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -311,6 +307,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),
@@ -341,6 +338,7 @@ mod test {
         let mock_connection = Arc::new(mock_database.into_connection());
 
         let workspace_service = WorkspaceServiceImpl::new(
+            mock_connection.clone(),
             "mock.database.host".to_owned(),
             5432,
             "postgres".to_owned(),


### PR DESCRIPTION
# create shcema without transaction

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.


## Description
This PR fixes a bug where the workspace table schema migration always fails. The bug occurs because the table schema migration is executed before the transaction creating the database schema is completed. The bug is fixed by separating the transaction for creating the database schema.