### PR TITLE
refactor: add if_not_exists checks in migration scripts

### DIFF
--- a/crates/nebula-authorization/src/database/workspace_migration/m20241128_001_init_authorization.rs
+++ b/crates/nebula-authorization/src/database/workspace_migration/m20241128_001_init_authorization.rs
@@ -42,6 +42,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(MachineIdentity::Table)
+                    .if_not_exists()
                     .col(char_len(MachineIdentity::Id, 26).primary_key())
                     .col(string_len(MachineIdentity::Label, 255))
                     .col(string_len(MachineIdentity::OwnerGid, 255))
@@ -54,6 +55,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(MachineIdentity::Table)
+                    .if_not_exists()
                     .name("idx_machine_identity_owner_gid")
                     .col(MachineIdentity::OwnerGid)
                     .take(),
@@ -64,6 +66,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(MachineIdentityAttribute::Table)
+                    .if_not_exists()
                     .col(char_len(MachineIdentityAttribute::Id, 26).primary_key())
                     .col(char_len(MachineIdentityAttribute::MachineIdentityId, 26))
                     .col(string_len(MachineIdentityAttribute::Key, 255))
@@ -77,6 +80,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(MachineIdentityAttribute::Table)
+                    .if_not_exists()
                     .name("idx_machine_identity_attribute_machine_identity_id")
                     .col(MachineIdentityAttribute::MachineIdentityId)
                     .take(),
@@ -87,6 +91,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(MachineIdentityToken::Table)
+                    .if_not_exists()
                     .col(char_len(MachineIdentityToken::Id, 26).primary_key())
                     .col(char_len(MachineIdentityToken::MachineIdentityId, 26))
                     .col(string_len(MachineIdentityToken::Token, 255))
@@ -99,6 +104,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(MachineIdentityToken::Table)
+                    .if_not_exists()
                     .name("idx_machine_identity_token_machine_identity_id")
                     .col(MachineIdentityToken::MachineIdentityId)
                     .take(),
@@ -109,7 +115,7 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(MachineIdentity::Table).take()).await?;
+        manager.drop_table(Table::drop().table(MachineIdentity::Table).if_exists().take()).await?;
 
         Ok(())
     }

--- a/crates/nebula-backbone/src/database/migration/m20241126_001_init_backbone.rs
+++ b/crates/nebula-backbone/src/database/migration/m20241126_001_init_backbone.rs
@@ -20,6 +20,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(Workspace::Table)
+                    .if_not_exists()
                     .col(char_len(Workspace::Id, 26).primary_key())
                     .col(string_len_uniq(Workspace::Name, 50))
                     .col(timestamp_with_time_zone(Workspace::CreatedAt))
@@ -30,6 +31,6 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(Workspace::Table).take()).await
+        manager.drop_table(Table::drop().table(Workspace::Table).if_exists().take()).await
     }
 }

--- a/crates/nebula-backbone/src/database/workspace_migration/m20241126_001_init_backbone.rs
+++ b/crates/nebula-backbone/src/database/workspace_migration/m20241126_001_init_backbone.rs
@@ -92,6 +92,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(AppliedPathPolicy::Table)
+                    .if_not_exists()
                     .col(char_len(AppliedPathPolicy::Id, 26).primary_key())
                     .col(char_len(AppliedPathPolicy::PathId, 26))
                     .col(text(AppliedPathPolicy::Expression))
@@ -104,6 +105,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(AppliedPathPolicyAllowedAction::Table)
+                    .if_not_exists()
                     .col(char_len(AppliedPathPolicyAllowedAction::Id, 26).primary_key())
                     .col(char_len(AppliedPathPolicyAllowedAction::AppliedPathPolicyId, 26))
                     .col(string_len(AppliedPathPolicyAllowedAction::Action, 50))
@@ -116,6 +118,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(AppliedPathPolicyAllowedAction::Table)
+                    .if_not_exists()
                     .name("idx_applied_path_policy_allowed_action_applied_path_policy_id")
                     .col(AppliedPathPolicyAllowedAction::AppliedPathPolicyId)
                     .take(),
@@ -125,6 +128,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(AppliedPolicy::Table)
+                    .if_not_exists()
                     .col(char_len(AppliedPolicy::Id, 26).primary_key())
                     .col(char_len(AppliedPolicy::SecretMetadataId, 26))
                     .col(string_len(AppliedPolicy::Type, 50))
@@ -138,6 +142,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(AppliedPolicy::Table)
+                    .if_not_exists()
                     .name("idx_applied_policy_secret_metadata_id")
                     .col(AppliedPolicy::SecretMetadataId)
                     .take(),
@@ -147,6 +152,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .table(AppliedPolicy::Table)
+                    .if_not_exists()
                     .name("idx_applied_policy_policy_id")
                     .col(AppliedPolicy::PolicyId)
                     .take(),
@@ -156,6 +162,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(Parameter::Table)
+                    .if_not_exists()
                     .col(char_len(Parameter::Id, 26).primary_key())
                     .col(integer(Parameter::Version))
                     .col(blob(Parameter::Value))
@@ -168,6 +175,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(Path::Table)
+                    .if_not_exists()
                     .col(char_len(Path::Id, 26).primary_key())
                     .col(text(Path::Path))
                     .col(timestamp_with_time_zone(Path::CreatedAt))
@@ -179,6 +187,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(Policy::Table)
+                    .if_not_exists()
                     .col(char_len(Policy::Id, 26).primary_key())
                     .col(string_len(Policy::Name, 100))
                     .col(text(Policy::Expression))
@@ -191,6 +200,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(SecretMetadata::Table)
+                    .if_not_exists()
                     .col(char_len(SecretMetadata::Id, 26).primary_key())
                     .col(string_len(SecretMetadata::Key, 100))
                     .col(string_len(SecretMetadata::Path, 100))
@@ -203,6 +213,7 @@ impl MigrationTrait for Migration {
             .create_table(
                 Table::create()
                     .table(SecretValue::Table)
+                    .if_not_exists()
                     .col(char_len(SecretValue::Id, 26).primary_key())
                     .col(string_len(SecretValue::Identifier, 10485760))
                     .col(blob(SecretValue::Cipher))
@@ -216,7 +227,7 @@ impl MigrationTrait for Migration {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager.drop_table(Table::drop().table(AppliedPathPolicy::Table).take()).await?;
+        manager.drop_table(Table::drop().table(AppliedPathPolicy::Table).if_exists().take()).await?;
 
         Ok(())
     }


### PR DESCRIPTION
# refactor: add if_not_exists checks in migration scripts

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

This pull request introduces a refactor in our database migration scripts by adding `IF NOT EXISTS` checks. These changes aim to enhance the reliability and idempotency of our migration processes, ensuring that scripts do not fail due to existing schema elements.