### PR TITLE
fix(authz): use structured params for workspace name

### DIFF
--- a/crates/nebula-authorization/src/server/router/mod.rs
+++ b/crates/nebula-authorization/src/server/router/mod.rs
@@ -79,8 +79,13 @@ pub(crate) fn router(application: Arc<Application>) -> axum::Router {
     Router::new().merge(public_router).merge(private_router)
 }
 
+#[derive(Deserialize)]
+pub(crate) struct WorkspaceParams {
+    pub workspace_name: String,
+}
+
 pub(crate) async fn check_workspace_name(
-    Path(workspace_name): Path<String>,
+    Path(WorkspaceParams { workspace_name }): Path<WorkspaceParams>,
     Extension(claim): Extension<NebulaClaim>,
     req: Request,
     next: Next,


### PR DESCRIPTION
# fix(authz): use structured params for workspace name
<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
This pull request fixes a bug where tuple-based path parameters were not being parsed correctly
