### PR TITLE
fix: validate attribute values as strings in NebulaClaim

### DIFF
--- a/crates/nebula-token/src/claim.rs
+++ b/crates/nebula-token/src/claim.rs
@@ -39,7 +39,14 @@ impl TryFrom<&JwtPayload> for NebulaClaim {
         Ok(NebulaClaim {
             gid,
             workspace_name,
-            attributes: attributes.into_iter().map(|(k, v)| (k, v.to_string())).collect(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| {
+                    let v = v.as_str()?.to_string();
+                    Some((k, v))
+                })
+                .collect::<Option<_>>()
+                .ok_or(JWTError::InvalidJwtFormat("attributes is not a map of strings".to_string()))?,
             role,
         })
     }


### PR DESCRIPTION
# fix: validate attribute values as strings in NebulaClaim

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request addresses an issue with the NebulaClaim component where attribute values were inconsistently treated when converted to strings. Previously, the `to_string()` method produced output in a quoted format, but this has been modified to ensure values are treated consistently as strings without additional quoting. 