### PR TITLE
refactor: remove test-only mock functions from wasm

### DIFF
--- a/crates/nebula-abe-wasm/src/lib.rs
+++ b/crates/nebula-abe-wasm/src/lib.rs
@@ -12,10 +12,7 @@ use nebula_abe::{
     curves::bn462::Bn462Curve,
     error::ABEError,
     random::miracl::MiraclRng,
-    schemes::isabella24::{
-        decrypt, encrypt, AuthorityKeyPair, AuthorityMasterKey, AuthorityPublicKey, Ciphertext, GlobalParams,
-        UserSecretKey,
-    },
+    schemes::isabella24::{decrypt, encrypt, AuthorityPublicKey, Ciphertext, GlobalParams, UserSecretKey},
 };
 use nebula_policy::pest::PolicyLanguage;
 use wasm_bindgen::prelude::*;
@@ -156,64 +153,4 @@ pub fn nebula_decrypt(gp: &str, sk: Vec<String>, ct: &str) -> Result<String, Neb
         message: e.to_string(),
         metadata: JsValue::null(),
     })
-}
-
-// -------------------
-// The below functions are for testing purposes only. will be removed in the future
-// -------------------
-
-#[wasm_bindgen]
-pub fn mock_global_params() -> Result<String, NebulaError> {
-    let mut rng = MiraclRng::new();
-    let mut seed = [0u8; 32];
-    getrandom(&mut seed).map_err(NebulaCryptError::GetRandom)?;
-    rng.seed(&seed);
-
-    let gp = GlobalParams::<Bn462Curve>::new(&mut rng);
-    let gp = rmp_serde::to_vec(&gp).map_err(NebulaCryptError::EncodeMessagePack)?;
-    Ok(STANDARD.encode(&gp))
-}
-
-#[wasm_bindgen(getter_with_clone)]
-pub struct AuthorityKey {
-    pub name: String,
-    pub pk: String,
-    pub mk: String,
-}
-
-#[wasm_bindgen]
-pub fn mock_authority(gp: &str, name: &str) -> Result<AuthorityKey, NebulaError> {
-    let mut rng = MiraclRng::new();
-    let mut seed = [0u8; 32];
-    getrandom(&mut seed).map_err(NebulaCryptError::GetRandom)?;
-    rng.seed(&seed);
-
-    let gp = STANDARD.decode(gp).map_err(NebulaCryptError::DecodeBase64)?;
-    let gp: GlobalParams<Bn462Curve> = rmp_serde::from_slice(&gp).map_err(NebulaCryptError::DecodeMessagePack)?;
-    let authority = AuthorityKeyPair::<Bn462Curve>::new(&mut rng, &gp, name);
-
-    let pk = rmp_serde::to_vec(&authority.pk).map_err(NebulaCryptError::EncodeMessagePack)?;
-    let pk = STANDARD.encode(&pk);
-    let mk = rmp_serde::to_vec(&authority.mk).map_err(NebulaCryptError::EncodeMessagePack)?;
-    let mk = STANDARD.encode(&mk);
-
-    Ok(AuthorityKey { name: name.to_string(), pk, mk })
-}
-
-#[wasm_bindgen]
-pub fn mock_user_secret_key(gp: &str, mk: &str, gid: &str, attributes: Vec<String>) -> Result<String, NebulaError> {
-    let mut rng = MiraclRng::new();
-    let mut seed = [0u8; 32];
-    getrandom(&mut seed).map_err(NebulaCryptError::GetRandom)?;
-    rng.seed(&seed);
-
-    let gp = STANDARD.decode(gp).map_err(NebulaCryptError::DecodeBase64)?;
-    let gp: GlobalParams<Bn462Curve> = rmp_serde::from_slice(&gp).map_err(NebulaCryptError::DecodeMessagePack)?;
-
-    let mk = STANDARD.decode(mk).map_err(NebulaCryptError::DecodeBase64)?;
-    let mk: AuthorityMasterKey<Bn462Curve> = rmp_serde::from_slice(&mk).map_err(NebulaCryptError::DecodeMessagePack)?;
-
-    let user_secret_key = UserSecretKey::<Bn462Curve>::new(&mut rng, &gp, &mk, gid, &attributes);
-    let user_secret_key = rmp_serde::to_vec(&user_secret_key).map_err(NebulaCryptError::EncodeMessagePack)?;
-    Ok(STANDARD.encode(&user_secret_key))
 }


### PR DESCRIPTION
# refactor: remove test-only mock functions from wasm

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.



