### PR TITLE
feat: refactor workspace path extraction using structs

### DIFF
--- a/crates/nebula-authority/src/server/mod.rs
+++ b/crates/nebula-authority/src/server/mod.rs
@@ -14,6 +14,7 @@ use nebula_token::{
     claim::{NebulaClaim, Role},
 };
 use reqwest::StatusCode;
+use serde::Deserialize;
 use tower_http::cors::AllowOrigin;
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
@@ -97,8 +98,13 @@ pub(super) async fn run(application: Application, config: ServerConfig) -> anyho
     Ok(())
 }
 
+#[derive(Deserialize)]
+pub(crate) struct WorkspaceParams {
+    pub workspace_name: String,
+}
+
 pub(crate) async fn check_workspace_name(
-    Path(workspace_name): Path<String>,
+    Path(WorkspaceParams { workspace_name }): Path<WorkspaceParams>,
     Extension(claim): Extension<NebulaClaim>,
     req: Request,
     next: Next,

--- a/crates/nebula-backbone/src/server/mod.rs
+++ b/crates/nebula-backbone/src/server/mod.rs
@@ -15,6 +15,7 @@ use reqwest::{
     header::{AUTHORIZATION, CONTENT_TYPE, LINK},
     StatusCode,
 };
+use serde::Deserialize;
 use tower_http::cors::AllowOrigin;
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
@@ -105,8 +106,14 @@ pub(crate) async fn check_member_role(
     }
 }
 
+#[derive(Deserialize)]
+pub(crate) struct WorkspaceParams {
+    pub workspace_name: String,
+}
+
 pub(crate) async fn check_workspace_name(
-    Path(workspace_name): Path<String>,
+    Path(WorkspaceParams { workspace_name }): Path<WorkspaceParams>,
+
     Extension(claim): Extension<NebulaClaim>,
     req: Request,
     next: Next,


### PR DESCRIPTION
# feat: refactor workspace path extraction using structs

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request improves the workspace path extraction process by transitioning from using tuples to custom-defined structures. Since tuples require a fixed number of elements, they were unsuitable for flexible path parsing. To address this limitation, I defined a new structure that allows for more adaptable handling of workspace paths

### Acknowledgement
https://github.com/CremitHQ/nebula/pull/131