### PR TITLE
fix(backbone): correct delete authority method to mark as deleted

### DIFF
--- a/crates/nebula-backbone/src/domain/authority/mod.rs
+++ b/crates/nebula-backbone/src/domain/authority/mod.rs
@@ -32,7 +32,7 @@ impl From<authority::Model> for Authority {
 
 impl Authority {
     pub fn delete(&mut self) {
-        self.deleted = false;
+        self.deleted = true;
     }
 
     pub fn update_name(&mut self, new_name: &str) {


### PR DESCRIPTION
# fix(backbone): correct delete authority method to mark as deleted

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request addresses an issue with the `delete` method within the backbone component by ensuring that instead of truly deleting, it correctly marks the authority as deleted.
