### PR TITLE
feat(cli): Add access condition and secret command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,13 @@ dependencies = [
  "async-trait",
  "cached_proc_macro",
  "cached_proc_macro_types",
+ "directories",
  "futures",
  "hashbrown 0.14.5",
  "once_cell",
+ "rmp-serde",
+ "serde",
+ "sled",
  "thiserror",
  "tokio",
  "web-time",
@@ -1100,6 +1104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,7 +1137,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
- "parking_lot",
+ "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1140,7 +1153,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
- "parking_lot",
+ "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1154,7 +1167,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
- "parking_lot",
+ "parking_lot 0.12.3",
  "rustix",
  "winapi",
 ]
@@ -1478,6 +1491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,7 +1556,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -2188,6 +2211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,13 +2697,19 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
+ "cached",
  "clap",
  "comfy-table",
  "config",
  "crossterm 0.27.0",
+ "futures-util",
  "inquire",
+ "nebula-abe",
  "nebula-config-path",
+ "rand",
  "reqwest",
+ "rmp-serde",
  "serde",
  "thiserror",
  "tokio",
@@ -2991,12 +3029,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3007,7 +3070,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3335,6 +3398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4186,6 +4258,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,7 +4800,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.0.2",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5307,7 +5395,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.5.7",
  "wasite",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ clap = { version = "4.5.19", features = ["cargo", "derive"] }
 sea-orm-migration = { version = "1.1.1", features = [
     "runtime-tokio-native-tls",
 ] }
+cached = { version = "0.54", features = [
+    "async",
+    "async_tokio_rt_multi_thread",
+] }
 # nebula crates
 nebula-miracl = { path = "crates/nebula-miracl" }
 nebula-policy = { path = "crates/nebula-policy" }

--- a/crates/nebula-authority/Cargo.toml
+++ b/crates/nebula-authority/Cargo.toml
@@ -25,10 +25,7 @@ thiserror = { workspace = true }
 axum_thiserror = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-cached = { version = "0.54", features = [
-    "async",
-    "async_tokio_rt_multi_thread",
-] }
+cached = { workspace = true }
 sea-orm = { workspace = true, features = ["mock"] }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }

--- a/crates/nebula-cli/Cargo.toml
+++ b/crates/nebula-cli/Cargo.toml
@@ -20,7 +20,16 @@ reqwest = { workspace = true, features = ["json"] }
 config = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 toml = "0.8"
-smol = "2"
+tokio = { workspace = true, features = ["full"] }
 inquire = "0.7.5"
+crossterm = "0.27"
+ulid = { workspace = true, features = ["serde"] }
+comfy-table = "7.1.3"
+futures-util = { workspace = true }
+cached = { workspace = true, features = ["disk_store", "rmp-serde"] }
+rmp-serde = { workspace = true }
+base64 = { workspace = true }
+rand = { workspace = true }
 # nebula crates
 nebula-config-path = { workspace = true }
+nebula-abe = { workspace = true }

--- a/crates/nebula-cli/src/api/authority.rs
+++ b/crates/nebula-cli/src/api/authority.rs
@@ -1,0 +1,46 @@
+use cached::proc_macro::io_cached;
+use reqwest::IntoUrl;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPublicKeyResponse {
+    pub public_key: String,
+    pub version: u64,
+}
+
+#[io_cached(
+    map_error = "|e| anyhow::anyhow!(e)",
+    disk = true,
+    time = 60,
+    key = "String",
+    convert = r#"{ format!("pk:{}/{}", authority_url.as_str(), workspace_name) }"#
+)]
+pub async fn get_public_key(authority_url: impl IntoUrl, workspace_name: &str) -> anyhow::Result<GetPublicKeyResponse> {
+    let client = reqwest::Client::new();
+
+    let url = authority_url.into_url()?.join(&format!("workspaces/{workspace_name}/public-key"))?;
+    let response = client.get(url).send().await?.json::<GetPublicKeyResponse>().await?;
+
+    Ok(response)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetUserKeyResponse {
+    pub user_key: String,
+    pub version: u64,
+}
+
+pub async fn get_user_key(
+    authority_url: impl IntoUrl,
+    workspace_name: &str,
+    token: &str,
+) -> anyhow::Result<GetUserKeyResponse> {
+    let client = reqwest::Client::new();
+
+    let url = authority_url.into_url()?.join(&format!("workspaces/{workspace_name}/user-key"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<GetUserKeyResponse>().await?;
+
+    Ok(response)
+}

--- a/crates/nebula-cli/src/api/authorization.rs
+++ b/crates/nebula-cli/src/api/authorization.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use reqwest::IntoUrl;
+use serde::Deserialize;
+
+const TOKEN_HEADER: &str = "Token";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MachineIdentityTokenResponse {
+    pub access_token: String,
+}
+
+pub async fn get_token_from_machine_identity_token(
+    authz_url: impl IntoUrl,
+    workspace_name: &str,
+    token: &str,
+) -> Result<String> {
+    let client = reqwest::Client::new();
+
+    let url = authz_url.into_url()?.join(&format!("workspaces/{workspace_name}/machine-identities/login"))?;
+    let response =
+        client.get(url).header(TOKEN_HEADER, token).send().await?.json::<MachineIdentityTokenResponse>().await?;
+
+    Ok(response.access_token)
+}

--- a/crates/nebula-cli/src/api/backbone.rs
+++ b/crates/nebula-cli/src/api/backbone.rs
@@ -1,0 +1,212 @@
+use anyhow::Result;
+use cached::proc_macro::{cached, io_cached};
+use reqwest::IntoUrl;
+use serde::{Deserialize, Serialize};
+use ulid::Ulid;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SecretResponse {
+    pub key: String,
+    pub path: String,
+    pub cipher: String,
+    pub access_condition_ids: Vec<Ulid>,
+}
+
+pub async fn get_secrets(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    path: &str,
+    token: &str,
+) -> Result<Vec<SecretResponse>> {
+    let client = reqwest::Client::new();
+
+    let mut url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/secrets"))?;
+    url.set_query(Some(&format!("path=/{}", path.trim_matches('/'))));
+    let response = client.get(url).bearer_auth(token).send().await?.json::<Vec<SecretResponse>>().await?;
+
+    Ok(response)
+}
+
+pub async fn get_secret_with_identifier(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    identifier: &str,
+    token: &str,
+) -> Result<SecretResponse> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url
+        .into_url()?
+        .join(&format!("workspaces/{workspace_name}/secrets/"))?
+        .join(identifier.trim_matches('/'))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<SecretResponse>().await?;
+
+    Ok(response)
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostSecretRequest {
+    pub path: String,
+    pub key: String,
+    pub cipher: String,
+    pub access_condition_ids: Vec<Ulid>,
+}
+
+pub async fn create_secret(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    request: PostSecretRequest,
+    token: &str,
+) -> Result<()> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/secrets"))?;
+    let response = client.post(url).bearer_auth(token).json(&request).send().await?;
+    response.error_for_status()?;
+
+    Ok(())
+}
+
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessConditionResponse {
+    pub id: Ulid,
+    pub name: String,
+    pub expression: String,
+}
+
+pub async fn get_access_conditions(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    token: &str,
+) -> Result<Vec<AccessConditionResponse>> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/policies"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<Vec<AccessConditionResponse>>().await?;
+
+    Ok(response)
+}
+
+#[cached(
+    result = true,
+    key = "String",
+    convert = r#"{ format!("ac:{}/{}/{}", backbone_url.as_str() ,workspace_name, id) }"#
+)]
+pub async fn get_access_condition(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    id: &Ulid,
+    token: &str,
+) -> Result<AccessConditionResponse> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/policies/{id}"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<AccessConditionResponse>().await?;
+
+    Ok(response)
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathResponse {
+    pub path: String,
+    pub applied_policies: Vec<AppliedPolicy>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppliedPolicy {
+    pub expression: String,
+    pub allowed_actions: Vec<AllowedAction>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AllowedAction {
+    Create,
+    Update,
+    Delete,
+    Manage,
+}
+
+pub async fn get_paths(backbone_url: impl IntoUrl, workspace_name: &str, token: &str) -> Result<Vec<PathResponse>> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/paths"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<Vec<PathResponse>>().await?;
+
+    Ok(response)
+}
+
+pub async fn get_path(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    path: &str,
+    token: &str,
+) -> Result<PathResponse> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/paths/{path}"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<PathResponse>().await?;
+
+    Ok(response)
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ParameterResponse {
+    pub version: i32,
+    pub parameter: String,
+}
+
+#[io_cached(
+    map_error = "|e| anyhow::anyhow!(e)",
+    disk = true,
+    time = 600,
+    key = "String",
+    convert = r#"{ format!("gp:{}/{}", backbone_url.as_str(), workspace_name) }"#
+)]
+pub async fn get_global_params(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    token: &str,
+) -> Result<ParameterResponse> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/parameter"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<ParameterResponse>().await?;
+
+    Ok(response)
+}
+
+#[derive(Deserialize, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorityResponse {
+    pub id: Ulid,
+    pub name: String,
+    pub host: String,
+    pub public_key: Option<String>,
+}
+
+#[io_cached(
+    map_error = "|e| anyhow::anyhow!(e)",
+    disk = true,
+    time = 60,
+    key = "String",
+    convert = r#"{ format!("authorities:{}/{}", backbone_url.as_str(), workspace_name) }"#
+)]
+pub async fn get_authorities(
+    backbone_url: impl IntoUrl,
+    workspace_name: &str,
+    token: &str,
+) -> Result<Vec<AuthorityResponse>> {
+    let client = reqwest::Client::new();
+
+    let url = backbone_url.into_url()?.join(&format!("workspaces/{workspace_name}/authorities"))?;
+    let response = client.get(url).bearer_auth(token).send().await?.json::<Vec<AuthorityResponse>>().await?;
+
+    Ok(response)
+}

--- a/crates/nebula-cli/src/api/mod.rs
+++ b/crates/nebula-cli/src/api/mod.rs
@@ -1,25 +1,3 @@
-use anyhow::Result;
-use reqwest::IntoUrl;
-use serde::Deserialize;
-
-const TOKEN_HEADER: &str = "Token";
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MachineIdentityTokenResponse {
-    pub access_token: String,
-}
-
-pub async fn get_token_from_machine_identity_token(
-    authz_url: impl IntoUrl,
-    workspace_name: &str,
-    token: &str,
-) -> Result<String> {
-    let client = reqwest::Client::new();
-
-    let url = authz_url.into_url()?.join(&format!("workspaces/{workspace_name}/machine-identities/login"))?;
-    let response =
-        client.get(url).header(TOKEN_HEADER, token).send().await?.json::<MachineIdentityTokenResponse>().await?;
-
-    Ok(response.access_token)
-}
+pub mod authority;
+pub mod authorization;
+pub mod backbone;

--- a/crates/nebula-cli/src/command/access_condition.rs
+++ b/crates/nebula-cli/src/command/access_condition.rs
@@ -1,0 +1,53 @@
+use async_trait::async_trait;
+use clap::{Args, Subcommand};
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::{Cell, Table};
+
+use crate::api::backbone::get_access_conditions;
+use crate::config::{load_token, NebulaConfig};
+
+use super::{GlobalArgs, RunCommand};
+
+#[derive(Subcommand, Debug)]
+pub enum AccessConditionCommand {
+    List(AccessConditionListCommand),
+}
+
+#[async_trait]
+impl RunCommand for AccessConditionCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        match self {
+            AccessConditionCommand::List(cmd) => cmd.run(args).await,
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct AccessConditionListCommand {}
+
+#[async_trait]
+impl RunCommand for AccessConditionListCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
+        let token = load_token()?;
+        let backbone_url = config.backbone.host;
+        let workspace_name = config.workspace;
+
+        let access_conditions = get_access_conditions(backbone_url.clone(), &workspace_name, &token).await?;
+
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+        table.set_header(vec!["ID", "Name", "Expression"]);
+
+        for access_condition in access_conditions {
+            table.add_row(vec![
+                Cell::new(access_condition.id),
+                Cell::new(access_condition.name),
+                Cell::new(access_condition.expression),
+            ]);
+        }
+        println!("{table}");
+        Ok(())
+    }
+}

--- a/crates/nebula-cli/src/command/login.rs
+++ b/crates/nebula-cli/src/command/login.rs
@@ -1,7 +1,11 @@
+use std::io::stdout;
+
 use async_trait::async_trait;
 use clap::Args;
+use crossterm::execute;
+use crossterm::style::{Color, Print, ResetColor, SetForegroundColor};
 
-use crate::api::get_token_from_machine_identity_token;
+use crate::api::authorization::get_token_from_machine_identity_token;
 use crate::config::{save_token, AuthorizationMethod, NebulaConfig};
 
 use super::{GlobalArgs, RunCommand};
@@ -27,6 +31,7 @@ impl RunCommand for LoginCommand {
             }
         };
 
+        execute!(stdout(), SetForegroundColor(Color::Green), Print("✅ Successfully logged in!\n"), ResetColor)?;
         Ok(())
     }
 }

--- a/crates/nebula-cli/src/command/mod.rs
+++ b/crates/nebula-cli/src/command/mod.rs
@@ -1,10 +1,14 @@
+use access_condition::AccessConditionCommand;
 use async_trait::async_trait;
 use clap::{command, Args, Parser};
 use config::ConfigCommand;
 use login::LoginCommand;
+use secret::SecretCommand;
 
+pub mod access_condition;
 pub mod config;
 pub mod login;
+pub mod secret;
 
 #[derive(Args, Debug)]
 pub struct GlobalArgs {
@@ -40,6 +44,10 @@ pub enum CliCommand {
     Login(LoginCommand),
     #[clap(subcommand)]
     Config(ConfigCommand),
+    #[clap(subcommand)]
+    Secret(SecretCommand),
+    #[clap(subcommand)]
+    AccessCondition(AccessConditionCommand),
 }
 
 #[async_trait]
@@ -51,6 +59,12 @@ impl RunCommand for CliCommand {
             }
             CliCommand::Login(ref login) => {
                 login.run(args).await?;
+            }
+            CliCommand::Secret(ref secret) => {
+                secret.run(args).await?;
+            }
+            CliCommand::AccessCondition(ref access_condition) => {
+                access_condition.run(args).await?;
             }
         }
         Ok(())

--- a/crates/nebula-cli/src/command/secret.rs
+++ b/crates/nebula-cli/src/command/secret.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+use std::io::stdout;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use base64::engine::{general_purpose::STANDARD, Engine as _};
+use clap::{Args, Subcommand};
+use comfy_table::modifiers::UTF8_ROUND_CORNERS;
+use comfy_table::presets::UTF8_FULL;
+use comfy_table::{Cell, Table};
+use crossterm::execute;
+use crossterm::style::{Color, Print, ResetColor, SetForegroundColor};
+use futures_util::future::join_all;
+use nebula_abe::curves::bn462::Bn462Curve;
+use nebula_abe::random::miracl::MiraclRng;
+use nebula_abe::schemes::isabella24::{decrypt, encrypt, AuthorityPublicKey, Ciphertext, GlobalParams, UserSecretKey};
+use nebula_abe::PolicyLanguage;
+use rand::rngs::OsRng;
+use rand::Rng as _;
+use ulid::Ulid;
+
+use crate::api::authority::{get_public_key, get_user_key};
+use crate::api::backbone::{
+    create_secret, get_access_condition, get_authorities, get_global_params, get_paths, get_secret_with_identifier,
+    get_secrets, PostSecretRequest,
+};
+use crate::config::{load_token, NebulaConfig};
+
+use super::{GlobalArgs, RunCommand};
+
+#[derive(Subcommand, Debug)]
+pub enum SecretCommand {
+    List(SecretListCommand),
+    Get(SecretGetCommand),
+    Create(SecretCreateCommand),
+}
+
+#[async_trait]
+impl RunCommand for SecretCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        match self {
+            SecretCommand::List(cmd) => cmd.run(args).await,
+            SecretCommand::Get(cmd) => cmd.run(args).await,
+            SecretCommand::Create(cmd) => cmd.run(args).await,
+        }
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct SecretListCommand {
+    #[clap(long, default_value = "/")]
+    path: String,
+}
+
+#[async_trait]
+impl RunCommand for SecretListCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
+        let token = load_token()?;
+        let backbone_url = config.backbone.host;
+        let workspace_name = config.workspace;
+
+        let paths = get_paths(backbone_url.clone(), &workspace_name, &token).await?;
+        let secrets = get_secrets(backbone_url.clone(), &workspace_name, &self.path, &token).await?;
+
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+        table.set_header(vec!["", "Path", "Access Condition"]);
+
+        for path_response in paths {
+            let search_path = self.path.trim_end_matches('/');
+            let search_path = if search_path.is_empty() { "/" } else { &format!("{}/", search_path) };
+
+            if !path_response.path.starts_with(search_path) {
+                continue;
+            }
+            let path = path_response.path.trim_start_matches(search_path);
+            if path.is_empty() || path.contains('/') {
+                continue;
+            }
+
+            table.add_row(vec![
+                Cell::new("📁").set_alignment(comfy_table::CellAlignment::Center),
+                Cell::new(format!("{}{}/", search_path, path)),
+            ]);
+        }
+
+        for secret in secrets {
+            let access_condition = join_all(
+                secret
+                    .access_condition_ids
+                    .iter()
+                    .map(|ac| get_access_condition(backbone_url.clone(), &workspace_name, ac, &token)),
+            )
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()?;
+
+            table.add_row(vec![
+                Cell::new("🔑").set_alignment(comfy_table::CellAlignment::Center),
+                Cell::new(format!("{}/{}", secret.path.trim_end_matches('/'), secret.key)),
+                Cell::new(access_condition.iter().map(|ac| ac.expression.clone()).collect::<Vec<_>>().join(" OR ")),
+            ]);
+        }
+
+        println!("{table}");
+
+        Ok(())
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct SecretGetCommand {
+    #[clap(long)]
+    path: String,
+}
+
+#[async_trait]
+impl RunCommand for SecretGetCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
+        let token = load_token()?;
+        let backbone_url = config.backbone.host;
+        let workspace_name = config.workspace;
+        let identifier = &self.path;
+
+        let gp = get_global_params(backbone_url.clone(), &workspace_name, &token).await?;
+        let gp = STANDARD.decode(gp.parameter)?;
+        let gp: GlobalParams<Bn462Curve> = rmp_serde::from_slice(&gp)?;
+
+        let authorities = get_authorities(backbone_url.clone(), &workspace_name, &token).await?;
+        let secret = get_secret_with_identifier(backbone_url, &workspace_name, identifier, &token).await?;
+        let ct = STANDARD.decode(secret.cipher)?;
+        let ct: Ciphertext<Bn462Curve> = rmp_serde::from_slice(&ct)?;
+
+        let mut usks = vec![];
+        for authority in authorities {
+            let usk = get_user_key(&authority.host, &workspace_name, &token).await?;
+
+            let usk = STANDARD.decode(&usk.user_key)?;
+            let usk: UserSecretKey<Bn462Curve> = rmp_serde::from_slice(&usk)?;
+            usks.push(usk);
+        }
+
+        let sk = UserSecretKey::<Bn462Curve>::sum(usks.into_iter())?;
+
+        let plaintext = decrypt(&gp, &sk, &ct)?;
+
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+        table.set_header(vec!["Path", "Plaintext"]);
+
+        table.add_row(vec![Cell::new(&self.path), Cell::new(String::from_utf8_lossy(&plaintext))]);
+
+        println!("{table}");
+
+        Ok(())
+    }
+}
+
+#[derive(Args, Debug)]
+pub struct SecretCreateCommand {
+    #[clap(long)]
+    path: String,
+
+    #[clap(short = 'v', long)]
+    value: String,
+
+    #[clap(long, value_delimiter = ',')]
+    access_condition_ids: Vec<String>,
+}
+
+#[async_trait]
+impl RunCommand for SecretCreateCommand {
+    async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
+        let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
+        let token = load_token()?;
+        let backbone_url = config.backbone.host;
+        let workspace_name = config.workspace;
+
+        let gp = get_global_params(backbone_url.clone(), &workspace_name, &token).await?;
+        let gp = STANDARD.decode(gp.parameter)?;
+        let gp: GlobalParams<Bn462Curve> = rmp_serde::from_slice(&gp)?;
+
+        let authorities = get_authorities(backbone_url.clone(), &workspace_name, &token).await?;
+        let mut pks = HashMap::new();
+        for authority in authorities {
+            let pk_response = get_public_key(&authority.host, &workspace_name).await?;
+
+            let pk = STANDARD.decode(&pk_response.public_key)?;
+            let pk: AuthorityPublicKey<Bn462Curve> = rmp_serde::from_slice(&pk)?;
+            pks.insert(format!("{}-{}#{}", authority.name, workspace_name, pk_response.version), pk);
+        }
+
+        let mut rng = MiraclRng::new();
+        let mut seed = [0u8; 64];
+        OsRng.fill(&mut seed);
+        rng.seed(&seed);
+
+        let mut policy = vec![];
+        for id in &self.access_condition_ids {
+            let access_condition =
+                get_access_condition(backbone_url.clone(), &workspace_name, &Ulid::from_str(id)?, &token).await?;
+            policy.push(access_condition.expression);
+        }
+        let policy = (policy.join(" OR "), PolicyLanguage::HumanPolicy);
+
+        let trimmed_path = self.path.trim_matches('/');
+        if trimmed_path.is_empty() {
+            return Err(anyhow::anyhow!("Invalid path"));
+        }
+        let path = format!("/{}", trimmed_path);
+        let key = path.split('/').last().unwrap().to_string();
+        let path = path.trim_end_matches(&key).to_string();
+
+        let ct = encrypt(&mut rng, &gp, &pks, policy, self.value.as_bytes())?;
+        let ct = rmp_serde::to_vec(&ct)?;
+        let ct = STANDARD.encode(&ct);
+
+        let access_condition_ids =
+            self.access_condition_ids.iter().map(|id| Ulid::from_str(id)).collect::<Result<Vec<_>, _>>()?;
+
+        let request = PostSecretRequest { path, key, cipher: ct, access_condition_ids };
+        create_secret(backbone_url.clone(), &workspace_name, request, &token).await?;
+
+        execute!(stdout(), SetForegroundColor(Color::Green), Print("✅ Successfully created secret\n"), ResetColor)?;
+
+        Ok(())
+    }
+}

--- a/crates/nebula-cli/src/main.rs
+++ b/crates/nebula-cli/src/main.rs
@@ -7,9 +7,10 @@ mod command;
 mod config;
 mod utils;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Cli::parse();
-    smol::block_on(async move { cli.run().await })?;
+    cli.run().await?;
 
     Ok(())
 }


### PR DESCRIPTION
# feat(cli): Add access condition and secret command

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request introduces two new command functionalities: Access Condition and Secret. With the addition of these commands, users gain the ability to manage access conditions and secrets directly through the command-line interface. 

### Access Condition Command
- New commands have been added to allow users to list access conditions.
- This functionality helps in retrieving an overview of the access conditions that are currently configured.

```bash 
$ nebula access-condition list
```


### Secret Command
- Users can now list, view individually (with decryption), and create (with encryption) secrets via the CLI.
- This provides a convenient way to handle sensitive data securely, ensuring that all operations maintain data privacy through encryption and decryption as needed.


```bash
# Create
$ nebula secret create --access-condition-ids 01JDGFCGXPX7EVPVP05GY8EG9C,01JE5QDH9CG3TTWT4DWZFJC4QM --path /test --value SECRET_VALUE

# List
$ nebula secret list

# Get
$ nebula secret get --path /test
```

Additional modifications include refactoring to utilize the `tokio` async runtime and updating dependencies for the `cached` library. This enhances the overall performance and stability of the CLI application.

