### PR TITLE
feat(authz): enhance SAML callback with port relay support

### DIFF
--- a/crates/nebula-token/src/jwt.rs
+++ b/crates/nebula-token/src/jwt.rs
@@ -18,7 +18,7 @@ use super::jwk::jwk_ext::JwkExt;
 pub struct Jwt {
     header: JwsHeader,
     payload: JwtPayload,
-    serialized_repr: String,
+    pub serialized_repr: String,
 }
 
 impl Jwt {


### PR DESCRIPTION
# feat(authz): enhance SAML callback with port relay support

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description

This pull request introduces an enhancement to the SAML authentication process by adding support for relaying ports via the RelayState parameter in the SAML callback. This allows for redirection back to a specific localhost port for the CLI login action.
