### PR TITLE
feat(cli): implement SAML login flow using HTTP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bon"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +921,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -967,6 +994,16 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -1059,6 +1096,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2247,6 +2294,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "josekit"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +2609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nebula-abe"
 version = "0.0.1"
 dependencies = [
@@ -2712,6 +2787,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "thiserror",
+ "tiny_http",
  "tokio",
  "toml",
  "tracing",
@@ -2719,6 +2795,7 @@ dependencies = [
  "ulid",
  "url",
  "validator",
+ "webbrowser",
 ]
 
 [[package]]
@@ -2892,6 +2969,40 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -4058,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4656,7 +4767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -4763,6 +4874,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d6ef4e10d23c1efb862eecad25c5054429a71958b4eeef85eb5e7170b477ca"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "log",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -5378,6 +5502,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9fe1ebb156110ff855242c1101df158b822487e4957b0556d9ffce9db0f535"
+dependencies = [
+ "block2",
+ "core-foundation 0.10.0",
+ "home",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,6 +5613,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5494,6 +5645,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5529,6 +5695,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5541,6 +5713,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5550,6 +5728,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5571,6 +5755,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5580,6 +5770,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5595,6 +5791,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -5604,6 +5806,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/nebula-cli/Cargo.toml
+++ b/crates/nebula-cli/Cargo.toml
@@ -30,6 +30,8 @@ cached = { workspace = true, features = ["disk_store", "rmp-serde"] }
 rmp-serde = { workspace = true }
 base64 = { workspace = true }
 rand = { workspace = true }
+webbrowser = "1.0"
+tiny_http = "0.11"
 # nebula crates
 nebula-config-path = { workspace = true }
 nebula-abe = { workspace = true }

--- a/crates/nebula-cli/src/command/access_condition.rs
+++ b/crates/nebula-cli/src/command/access_condition.rs
@@ -30,7 +30,7 @@ pub struct AccessConditionListCommand {}
 impl RunCommand for AccessConditionListCommand {
     async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
-        let token = load_token()?;
+        let token = load_token(&args.profile)?;
         let backbone_url = config.backbone.host;
         let workspace_name = config.workspace;
 

--- a/crates/nebula-cli/src/command/login.rs
+++ b/crates/nebula-cli/src/command/login.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use clap::Args;
 use crossterm::execute;
 use crossterm::style::{Color, Print, ResetColor, SetForegroundColor};
+use rand::Rng;
+use tiny_http::{Response, Server};
 
 use crate::api::authorization::get_token_from_machine_identity_token;
 use crate::config::{save_token, AuthorizationMethod, NebulaConfig};
@@ -18,7 +20,31 @@ impl RunCommand for LoginCommand {
     async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
         match config.authorization.method {
-            AuthorizationMethod::Saml => unimplemented!(),
+            AuthorizationMethod::Saml => {
+                let port: u16 = rand::thread_rng().gen_range(1024..65535);
+                let server = Server::http(("0.0.0.0", port)).map_err(|e| anyhow::anyhow!(e))?;
+                execute!(
+                    stdout(),
+                    SetForegroundColor(Color::Blue),
+                    Print("🔗 Opening browser for SAML login...\n"),
+                    ResetColor
+                )?;
+                webbrowser::open(
+                    config.authorization.host.join(&format!("login/saml?callback-port={port}"))?.as_str(),
+                )?;
+
+                for request in server.incoming_requests() {
+                    let url = request.url();
+                    if url.starts_with("/callback/saml?access-token=") {
+                        let token = url.trim_start_matches("/callback/saml?access-token=");
+                        let response =
+                            Response::from_string("Successfully logged in! Close this tab and return to the terminal.");
+                        save_token(&args.profile, token)?;
+                        request.respond(response)?;
+                        break;
+                    }
+                }
+            }
             AuthorizationMethod::MachineIdentity { token } => {
                 let token = get_token_from_machine_identity_token(
                     config.authorization.host.clone(),
@@ -27,7 +53,7 @@ impl RunCommand for LoginCommand {
                 )
                 .await?;
 
-                save_token(&token)?;
+                save_token(&args.profile, &token)?;
             }
         };
 

--- a/crates/nebula-cli/src/command/secret.rs
+++ b/crates/nebula-cli/src/command/secret.rs
@@ -56,7 +56,7 @@ pub struct SecretListCommand {
 impl RunCommand for SecretListCommand {
     async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
-        let token = load_token()?;
+        let token = load_token(&args.profile)?;
         let backbone_url = config.backbone.host;
         let workspace_name = config.workspace;
 
@@ -119,7 +119,7 @@ pub struct SecretGetCommand {
 impl RunCommand for SecretGetCommand {
     async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
-        let token = load_token()?;
+        let token = load_token(&args.profile)?;
         let backbone_url = config.backbone.host;
         let workspace_name = config.workspace;
         let identifier = &self.path;
@@ -174,7 +174,7 @@ pub struct SecretCreateCommand {
 impl RunCommand for SecretCreateCommand {
     async fn run(&self, args: &GlobalArgs) -> anyhow::Result<()> {
         let config = NebulaConfig::load(args.profile.as_str(), args.config.clone().map(Into::into))?;
-        let token = load_token()?;
+        let token = load_token(&args.profile)?;
         let backbone_url = config.backbone.host;
         let workspace_name = config.workspace;
 

--- a/crates/nebula-cli/src/config/mod.rs
+++ b/crates/nebula-cli/src/config/mod.rs
@@ -88,8 +88,8 @@ pub enum AuthorizationMethod {
     MachineIdentity { token: String },
 }
 
-const NEBULA_PATH: &str = "nebula";
-const TOKEN_PATH: &str = ".token";
+const NEBULA_PATH: &str = "nebula/";
+const TOKEN_PATH: &str = ".token/";
 
 fn config_file_path(config_path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     if let Some(path_override) = config_path {
@@ -104,13 +104,13 @@ fn config_file_path(config_path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     }
 }
 
-fn token_file_path() -> anyhow::Result<PathBuf> {
+fn token_file_path(profile: &str) -> anyhow::Result<PathBuf> {
     let user_config_dir = config_dir().ok_or_else(|| anyhow::anyhow!("Failed to get user config directory"))?;
-    let nebula_config_dir = user_config_dir.join(NEBULA_PATH);
-    if !nebula_config_dir.exists() {
-        std::fs::create_dir_all(&nebula_config_dir)?;
+    let token_dir = user_config_dir.join(NEBULA_PATH).join(TOKEN_PATH);
+    if !token_dir.exists() {
+        std::fs::create_dir_all(&token_dir)?;
     }
-    Ok(nebula_config_dir.join(TOKEN_PATH))
+    Ok(token_dir.join(format!("{}.token", profile)))
 }
 
 pub fn has_profile(profile: &str, config_path: Option<PathBuf>) -> anyhow::Result<bool> {
@@ -124,14 +124,14 @@ pub fn has_profile(profile: &str, config_path: Option<PathBuf>) -> anyhow::Resul
     Ok(config.profiles.into_iter().any(|c| c.name == profile))
 }
 
-pub fn load_token() -> anyhow::Result<String> {
-    let token_path = token_file_path()?;
+pub fn load_token(profile: &str) -> anyhow::Result<String> {
+    let token_path = token_file_path(profile)?;
 
     Ok(std::fs::read_to_string(token_path)?)
 }
 
-pub fn save_token(token: &str) -> anyhow::Result<()> {
-    let token_path = token_file_path()?;
+pub fn save_token(profile: &str, token: &str) -> anyhow::Result<()> {
+    let token_path = token_file_path(profile)?;
 
     Ok(std::fs::write(token_path, token)?)
 }


### PR DESCRIPTION
# feat(cli): implement SAML login flow using HTTP server

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request introduces a new feature to the CLI tool, enabling users to perform SAML login using a local HTTP server. This enhancement facilitates the SAML authentication process, making it more seamless and integrated within the CLI.

In addition to the core functionality, changes in this pull request include:
- Passing profile data to `load_token` function to ensure proper handling of SAML tokens associated with different user profiles.
