### PR TITLE
fix: remove redundant path check for root "/"

### DIFF
--- a/crates/nebula-backbone/src/domain/secret/mod.rs
+++ b/crates/nebula-backbone/src/domain/secret/mod.rs
@@ -991,10 +991,6 @@ impl PostgresSecretService {
 }
 
 async fn ensure_path_not_duplicated(transaction: &DatabaseTransaction, path: &str) -> Result<()> {
-    if path == "/" {
-        return Err(Error::PathDuplicated { entered_path: path.to_owned() });
-    }
-
     if path::Entity::find().filter(path::Column::Path.eq(path)).count(transaction).await? > 0 {
         return Err(Error::PathDuplicated { entered_path: path.to_owned() });
     }


### PR DESCRIPTION
# fix: remove redundant path check for root "/"

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request addresses a bug in our path management logic where the creation of new paths would fail due to the incorrect assumption that the root path is always present by default. The existing implementation includes a redundant check for the root path ("/"), which prevents new paths from being created when the root is absent. 

This update removes the unnecessary check, allowing new paths to be generated correctly and ensuring that the system properly handles the creation of the root path when necessary.
