### PR TITLE
fix: remove unused column from applied_policy table

### DIFF
--- a/crates/nebula-backbone/src/database/workspace_migration/m20241206_001_remove_unused_column_applied_policy_table.rs
+++ b/crates/nebula-backbone/src/database/workspace_migration/m20241206_001_remove_unused_column_applied_policy_table.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use sea_orm_migration::{prelude::*, schema::*};
+
+#[derive(DeriveIden)]
+pub enum AppliedPolicy {
+    Table,
+    Type,
+}
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(Table::alter().table(AppliedPolicy::Table).drop_column(AppliedPolicy::Type).to_owned())
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AppliedPolicy::Table)
+                    .add_column_if_not_exists(string_len(AppliedPolicy::Type, 50))
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/nebula-backbone/src/database/workspace_migration/mod.rs
+++ b/crates/nebula-backbone/src/database/workspace_migration/mod.rs
@@ -7,6 +7,7 @@ use super::{workspace, AuthMethod};
 
 mod m20241126_001_init_backbone;
 mod m20241128_001_create_authority_table;
+mod m20241206_001_remove_unused_column_applied_policy_table;
 
 pub struct Migrator;
 
@@ -16,6 +17,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20241126_001_init_backbone::Migration),
             Box::new(m20241128_001_create_authority_table::Migration),
+            Box::new(m20241206_001_remove_unused_column_applied_policy_table::Migration),
         ]
     }
 }


### PR DESCRIPTION
# fix: remove unused column from applied_policy table

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->


## Description
This pull request addresses an issue with the `applied_policy` table by removing an unused column that was causing conflicts during data insertion. The `type` column was identified as redundant and has been removed to prevent insertion errors and improve table integrity.

### Reference
#156 