### PR TITLE
fix(config): ensure config file creation if missing

### DIFF
--- a/crates/nebula-cli/src/config/mod.rs
+++ b/crates/nebula-cli/src/config/mod.rs
@@ -47,6 +47,10 @@ impl NebulaConfig {
 
     pub fn append(&self) -> anyhow::Result<()> {
         let config_file_path = config_file_path(None)?;
+        if !config_file_path.exists() {
+            std::fs::write(&config_file_path, "")?;
+        }
+
         let mut config: NebulaConfigs = Config::builder()
             .add_source(File::from(config_file_path.clone()).format(FileFormat::Toml))
             .build()?


### PR DESCRIPTION
# fix(config): ensure config file creation if missing

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

This pull request addresses an issue where the configuration file was not being automatically created if it was missing. The change ensures that when the application starts, it checks for the existence of the configuration file. If the file does not exist, the application will create one using default settings, preventing errors related to missing configurations.