### PR TITLE
Initialize root path and parameter when initializing workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,7 +2616,7 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nebula-abe"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-abe-wasm"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "base64 0.22.1",
  "console_error_panic_hook",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-authority"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-authorization"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-backbone"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2804,18 +2804,18 @@ dependencies = [
 
 [[package]]
 name = "nebula-common"
-version = "0.0.1"
+version = "0.0.2"
 
 [[package]]
 name = "nebula-config-path"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "nebula-miracl"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "serde",
  "zeroize",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-policy"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "pest",
  "pest_derive",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-secret-sharing"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "rand",
  "serde",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-storage"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "aes-gcm",
  "bon",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "nebula-token"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["John Choi <john@cremit.io>"]
 repository = "https://github.com/cremithq/nebula"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.0.2"
 edition = "2021"
-authors = ["John Choi <john@cremit.io>"]
+authors = ["John Choi <john@cremit.io>", "Boris Im <boris@cremit.io>"]
 repository = "https://github.com/cremithq/nebula"
 keywords = ["secret", "vault"]
 categories = ["security"]

--- a/crates/nebula-backbone/src/application/mod.rs
+++ b/crates/nebula-backbone/src/application/mod.rs
@@ -46,7 +46,12 @@ pub(crate) struct Application {
 
 impl Application {
     pub fn workspace(&self) -> impl WorkspaceUseCase {
-        WorkspaceUseCaseImpl::new(self.database_connection.clone(), self.workspace_service.clone())
+        WorkspaceUseCaseImpl::new(
+            self.database_connection.clone(),
+            self.workspace_service.clone(),
+            self.secret_service.clone(),
+            self.parameter_service.clone(),
+        )
     }
 
     pub fn with_workspace(&self, workspace_name: &str) -> ApplicationWithWorkspace {

--- a/crates/nebula-backbone/src/server/mod.rs
+++ b/crates/nebula-backbone/src/server/mod.rs
@@ -44,11 +44,11 @@ pub(super) async fn run(application: Application, config: ServerConfig) -> anyho
     let application = Arc::new(application);
     let public_router = Router::new()
         .route("/health", get(|| async { "" }))
-        .nest("/workspaces", router::workspace::public_router(application.clone()))
+        .merge(router::workspace::public_router(application.clone()))
         .merge(router::parameter::public_router(application.clone()));
 
     let protected_router = Router::new()
-        .nest("/workspaces", router::workspace::router(application.clone()))
+        .merge(router::workspace::router(application.clone()))
         .merge(router::secret::router(application.clone()))
         .merge(router::parameter::router(application.clone()))
         .merge(router::policy::router(application.clone()))

--- a/crates/nebula-backbone/src/server/router/workspace/mod.rs
+++ b/crates/nebula-backbone/src/server/router/workspace/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn public_router(application: Arc<Application>) -> axum::Router {
 
 pub(crate) fn router(application: Arc<Application>) -> axum::Router {
     let admin_routers = Router::new()
-        .route("/:workspace_name", delete(handle_delete_workspace))
+        .route("/workspaces/:workspace_name", delete(handle_delete_workspace))
         .route_layer(middleware::from_fn(check_admin_role))
         .route_layer(middleware::from_fn(check_workspace_name));
     Router::new().merge(admin_routers).with_state(application)


### PR DESCRIPTION
# Initialize root path and parameter when initializing workspace

<!-- Thank you for submitting a pull request to our repo. -->

- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

this PR implements initializing process of root path and parameter when intializing workspaces.
and also merge workspaces router instead of nesting